### PR TITLE
fix: Move analytics class to end of class list

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
                         <p>Fundraising for SEEK2026</p>
                     </div>
                     <div class="header-buttons">
-                        <a href="rdir/booking.html" class="umami--click--booking" class="button booking-button" target="_blank" rel="noopener noreferrer">Book Now</a>
+                        <a href="rdir/booking.html" class="button booking-button umami--click--booking" target="_blank" rel="noopener noreferrer">Book Now</a>
                     </div>
                 </section>
 
@@ -75,7 +75,7 @@
                 <!-- This section highlights any special offers or promotions. -->
                 <section id="promotions">
                     <h2>Promotions</h2>
-                    <a href="new-client-promotion.html" class="umami--click--new-client-promo" class="card-link">
+                    <a href="new-client-promotion.html" class="card-link umami--click--new-client-promo">
                         <div class="promotion-details">
                             <h3>New Client Promotion</h3>
                             <p>Your First Weekday 30-Minute Walk - 50% Off! (Just $9)</p>

--- a/new-client-promotion.html
+++ b/new-client-promotion.html
@@ -34,7 +34,7 @@
         </div>
         <div class="header-buttons">
             <a href="index.html" class="button">Home</a>
-            <a href="rdir/booking.html" class="umami--click--booking" class="button booking-button" target="_blank" rel="noopener noreferrer">Book Now</a>
+            <a href="rdir/booking.html" class="button booking-button umami--click--booking" target="_blank" rel="noopener noreferrer">Book Now</a>
         </div>
     </header>
 
@@ -49,7 +49,7 @@
             </div>
             <div class="header-buttons">
                 <a href="index.html" class="button">Home</a>
-                <a href="rdir/booking.html" class="umami--click--booking-new-client-promo" class="button booking-button" target="_blank" rel="noopener noreferrer">Book Now</a>
+                <a href="rdir/booking.html" class="button booking-button umami--click--booking-new-client-promo" target="_blank" rel="noopener noreferrer">Book Now</a>
             </div>
         </section>
 


### PR DESCRIPTION
Moves the Umami analytics class to be the last class in the class attribute of HTML elements. This prevents the analytics class from interfering with the styling of the elements, particularly buttons.